### PR TITLE
genmbr.py: Update to Python 3

### DIFF
--- a/genmbr.py
+++ b/genmbr.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
+import struct
 import sys
 
-assert sys.version_info.major >= 3, 'requires Python 3'
-
 def writeU32LE(out, value):
-	out.write(bytes([(value >> shift) & 0xFF for shift in range(0, 32, 8)]))
+	out.write(struct.pack('<I', value))
 
 def writeMBR(out, partitions):
 	partitions = list(partitions)


### PR DESCRIPTION
While the script worked with Python 3 (after replacing xrange with range), it produced a corrupt image.
Updates the script to Python 3.

```
$ md5sum images/mbr.bin
853f96cb0dd612892c2a136ab2619382  images/mbr.bin
```