### PR TITLE
Use a custom config for mkfs

### DIFF
--- a/create_data_image.sh
+++ b/create_data_image.sh
@@ -33,9 +33,8 @@ IMAGE_SIZE=$((8 + ${TOTAL_SIZE} / (920*1024)))
 echo "Creating data partition of ${IMAGE_SIZE} MB..."
 mkdir -p images
 dd if=/dev/zero of=images/data.bin bs=1M count=${IMAGE_SIZE}
-/sbin/mkfs.ext4 -b4096 -I128 -m3 \
+MKE2FS_CONFIG=mke2fs.conf /sbin/mkfs.ext4 -b4096 -I128 -m3 \
 		-E lazy_itable_init=0,lazy_journal_init=0,resize=268435456 \
-		-O large_file,^huge_file,^uninit_bg,^ext_attr \
 		-F images/data.bin
 echo
 

--- a/create_data_image.sh
+++ b/create_data_image.sh
@@ -33,9 +33,7 @@ IMAGE_SIZE=$((8 + ${TOTAL_SIZE} / (920*1024)))
 echo "Creating data partition of ${IMAGE_SIZE} MB..."
 mkdir -p images
 dd if=/dev/zero of=images/data.bin bs=1M count=${IMAGE_SIZE}
-MKE2FS_CONFIG=mke2fs.conf /sbin/mkfs.ext4 -b4096 -I128 -m3 \
-		-E lazy_itable_init=0,lazy_journal_init=0,resize=268435456 \
-		-F images/data.bin
+MKE2FS_CONFIG=mke2fs.conf /sbin/mke2fs -t od-data -m3 -F images/data.bin
 echo
 
 echo "Populating data partition..."

--- a/create_data_image.sh
+++ b/create_data_image.sh
@@ -33,7 +33,7 @@ IMAGE_SIZE=$((8 + ${TOTAL_SIZE} / (920*1024)))
 echo "Creating data partition of ${IMAGE_SIZE} MB..."
 mkdir -p images
 dd if=/dev/zero of=images/data.bin bs=1M count=${IMAGE_SIZE}
-MKE2FS_CONFIG=mke2fs.conf /sbin/mke2fs -t od-data -m3 -F images/data.bin
+MKE2FS_CONFIG=mke2fs.conf /sbin/mke2fs -t od-data -F images/data.bin
 echo
 
 echo "Populating data partition..."

--- a/mke2fs.conf
+++ b/mke2fs.conf
@@ -9,9 +9,10 @@
 		features = has_journal,extent
 		blocksize = 4096
 		inode_size = 256
-		inode_ratio = 16384
+		inode_ratio = 32768
 		lazy_itable_init = 0
 		lazy_journal_init = 0
+		reserved_ratio = 3
 		resize = 268435456
 	}
 

--- a/mke2fs.conf
+++ b/mke2fs.conf
@@ -1,0 +1,48 @@
+[defaults]
+	base_features = sparse_super,large_file,filetype,resize_inode,dir_index
+	default_mntopts = acl,user_xattr
+	enable_periodic_fsck = 0
+	blocksize = 4096
+	inode_size = 256
+	inode_ratio = 16384
+
+[fs_types]
+	ext3 = {
+		features = has_journal
+	}
+	ext4 = {
+		features = has_journal,extent
+		inode_size = 256
+	}
+	small = {
+		inode_size = 128
+		inode_ratio = 4096
+	}
+	floppy = {
+		inode_size = 128
+		inode_ratio = 8192
+	}
+	big = {
+		inode_ratio = 32768
+	}
+	huge = {
+		inode_ratio = 65536
+	}
+	news = {
+		inode_ratio = 4096
+	}
+	largefile = {
+		inode_ratio = 1048576
+		blocksize = -1
+	}
+	largefile4 = {
+		inode_ratio = 4194304
+		blocksize = -1
+	}
+	hurd = {
+	     blocksize = 4096
+	     inode_size = 128
+	}
+
+[options]
+	fname_encoding = utf8

--- a/mke2fs.conf
+++ b/mke2fs.conf
@@ -2,46 +2,17 @@
 	base_features = sparse_super,large_file,filetype,resize_inode,dir_index
 	default_mntopts = acl,user_xattr
 	enable_periodic_fsck = 0
-	blocksize = 4096
-	inode_size = 256
-	inode_ratio = 16384
 
 [fs_types]
-	ext3 = {
-		features = has_journal
-	}
-	ext4 = {
+	# Based on ext4 with some features disabled
+	od-data = {
 		features = has_journal,extent
+		blocksize = 4096
 		inode_size = 256
-	}
-	small = {
-		inode_size = 128
-		inode_ratio = 4096
-	}
-	floppy = {
-		inode_size = 128
-		inode_ratio = 8192
-	}
-	big = {
-		inode_ratio = 32768
-	}
-	huge = {
-		inode_ratio = 65536
-	}
-	news = {
-		inode_ratio = 4096
-	}
-	largefile = {
-		inode_ratio = 1048576
-		blocksize = -1
-	}
-	largefile4 = {
-		inode_ratio = 4194304
-		blocksize = -1
-	}
-	hurd = {
-	     blocksize = 4096
-	     inode_size = 128
+		inode_ratio = 16384
+		lazy_itable_init = 0
+		lazy_journal_init = 0
+		resize = 268435456
 	}
 
 [options]


### PR DESCRIPTION
### Problem

mkfs uses system defaults for creating the image (-O options override the defaults but do not replace them).

Newer Linux distributions come with a config that has default features
not supported on our old buildroot.

### Solution

Provide an explicit config file for mkfs.

Diff with system one from my Ubuntu 19.04:
https://gist.github.com/glebm/2334fd6a79fcb61305dfb89d98939841
