### PR TITLE
 Unmount data partition before resizing 

### DIFF
--- a/create_data_image.sh
+++ b/create_data_image.sh
@@ -47,7 +47,8 @@ ${SU_CMD} "
 		install -m 644 -o ${USER_UID} -g ${USER_GID} -t mnt/apps/ ${APPS}
 	fi &&
 	install -m 755 -o 0 -g 0 -d mnt/local/etc/init.d &&
-	install -m 755 -o 0 -g 0 resize_data_part.target-sh mnt/local/etc/init.d/S00resize &&
+	install -m 755 -o 0 -g 0 resize_data_part_launcher.target-sh mnt/local/etc/init.d/S00resize &&
+	install -m 755 -o 0 -g 0 resize_data_part.target-sh mnt/resize_data_part.sh &&
 	umount mnt
 	"
 rmdir mnt

--- a/resize_data_part.target-sh
+++ b/resize_data_part.target-sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 DEVICE=mmcblk0
 PART_NUM=2
 
@@ -7,14 +9,39 @@ DEVICE_SIZE=`cat /sys/block/${DEVICE}/size`
 START=`partx /dev/${DEVICE} -n ${PART_NUM} -g -o start`
 SIZE=$((${DEVICE_SIZE} - ${START}))
 
-echo "${START},${SIZE}" | sfdisk --no-reread -uS -N ${PART_NUM} /dev/${DEVICE}
+mount_data_partition() {
+	echo "Mounting the partition..."
+	/bin/mount -o remount,rw /media
+	/bin/mount "/dev/${DEVICE}p${PART_NUM}" /media/data
+	/bin/mount -o remount,ro /media
+}
 
 clear
 echo 1 > /sys/devices/virtual/vtconsole/vtcon1/bind
 echo "Resizing the data partition. Please be patient."
 
-set +e
+# Unmount data partition before resizing for faster resizing.
+echo "Unmounting the partition..."
+/bin/mount -o remount,rw /media
+/bin/umount /media/data
+/bin/mount -o remount,ro /media
+# Try to remount the data partition on error (early EXIT is an error).
+trap mount_data_partition EXIT
+
+echo "Updating partition table..."
+
+# If the --no-reread option is not supported, this command will fail (|| true takes care of that)
+echo "${START},${SIZE}" | sfdisk --no-reread -uS -N ${PART_NUM} /dev/${DEVICE} || true
+
+clear # Previous command has very noisy output
+echo "Resizing the data partition. Please be patient."
 resizepart /dev/${DEVICE} ${PART_NUM} ${SIZE}
 resize2fs /dev/${DEVICE}p${PART_NUM}
 
-rm $0
+# Clear the trap that attempts to mount the partition.
+trap - EXIT
+mount_data_partition
+
+rm /media/data/local/etc/init.d/S00resize
+rm /media/data/resize_data_part.sh
+rm "$0"

--- a/resize_data_part.target-sh
+++ b/resize_data_part.target-sh
@@ -18,7 +18,8 @@ mount_data_partition() {
 
 clear
 echo 1 > /sys/devices/virtual/vtconsole/vtcon1/bind
-echo "Resizing the data partition. Please be patient."
+echo "Resizing the data partition."
+echo "This will take a few minutes"
 
 # Unmount data partition before resizing for faster resizing.
 echo "Unmounting the partition..."
@@ -27,15 +28,23 @@ echo "Unmounting the partition..."
 /bin/mount -o remount,ro /media
 # Try to remount the data partition on error (early EXIT is an error).
 trap mount_data_partition EXIT
+echo
 
 echo "Updating partition table..."
-
-# If the --no-reread option is not supported, this command will fail (|| true takes care of that)
-echo "${START},${SIZE}" | sfdisk --no-reread -uS -N ${PART_NUM} /dev/${DEVICE} || true
-
-clear # Previous command has very noisy output
-echo "Resizing the data partition. Please be patient."
+SFDISK_OPTS="--no-reread --quiet -uS -N ${PART_NUM}"
+# Older versions of sfdisk do not support --no-tell-kernel.
+HAS_NO_TELL_KERNEL=n
+if sfdisk --help | grep -- --no-tell-kernel > /dev/null; then
+	HAS_NO_TELL_KERNEL=y
+	SFDISK_OPTS="${SFDISK_OPTS} --no-tell-kernel"
+fi
+echo "${START},${SIZE}" | sfdisk ${SFDISK_OPTS} /dev/${DEVICE}
+if [ "$HAS_NO_TELL_KERNEL" = n ]; then
+	echo "Re-reading error above is expected."
+fi
 resizepart /dev/${DEVICE} ${PART_NUM} ${SIZE}
+echo
+
 resize2fs /dev/${DEVICE}p${PART_NUM}
 
 # Clear the trap that attempts to mount the partition.

--- a/resize_data_part_launcher.target-sh
+++ b/resize_data_part_launcher.target-sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+# Copy the resize script to tmpfs and run it.
+# We have to do this so that we can unmount the partition.
+echo 'Launching data partition resizer...'
+cp /media/data/resize_data_part.sh /tmp/resize_data_part.sh
+chmod +x /tmp/resize_data_part.sh
+exec /tmp/resize_data_part.sh


### PR DESCRIPTION
This results in a faster resize as resize2fs can perform an "offline"
resize instead of an "online" one.

Timings for me on RG350 with a stock 16G SD card are:
online: 3m45s
offline: 3m10s

(based on top of #4)